### PR TITLE
複合代入演算子の使用例の間違いを修正

### DIFF
--- a/books/rust-atcoder/27-boolean.md
+++ b/books/rust-atcoder/27-boolean.md
@@ -364,7 +364,7 @@ fn main() {
     }
     let mut ans = true;
     for i in 0..s.len() {
-        ans &= (i % 2 == 0) ^ s[i].is_ascii_uppercase();
+        ans &= !((i % 2 == 0) ^ s[i].is_ascii_uppercase());
     }
     println!("{}", if ans { "Yes" } else { "No" });
 }


### PR DESCRIPTION
&=の後の条件が反対になっていたので!()でくくり反転させ修正。